### PR TITLE
startup checks on start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -14,5 +14,19 @@
 # @link http://www.PieMC-Dev.github.io/
 
 import subprocess
+def check_python_version():
+    try:
+        # Attempt to run the 'python' command and check if it's available
+        subprocess.check_output('python --version', shell=True)
+        return 'python'
+    except subprocess.CalledProcessError:
+        try:
+            # Attempt to run the 'python3' command and check if it's available
+            subprocess.check_output('python3 --version', shell=True)
+            return 'python3'
+        except subprocess.CalledProcessError:
+            raise Exception("Neither 'python' nor 'python3' found in your system.")
 
+selected_python_command = check_python_version()
+print(f"launching with the command: {selected_python_command}")
 subprocess.call(['python', '-m', 'piemc'])


### PR DESCRIPTION
checks for which command should the startup srcipt use for launching

for example sometimes python launches with python3 or python, so the check just fixes that issue for most platforms
![thrthrthrthrt](https://github.com/PieMC-Dev/PieMC/assets/84281752/bed664d7-bbb2-4971-961f-b5429358577f)
