### PR TITLE
Improved starting commands

### DIFF
--- a/piemc/__init__.py
+++ b/piemc/__init__.py
@@ -10,3 +10,5 @@
 #
 # @author PieMC Team
 # @link http://www.PieMC-Dev.github.io/
+
+from .start import main

--- a/piemc/__main__.py
+++ b/piemc/__main__.py
@@ -11,9 +11,7 @@
 # @author PieMC Team
 # @link http://www.PieMC-Dev.github.io/
 
-from piemc import config
-from piemc.server import PieServer
+from .start import main
 
 if __name__ == "__main__":
-    server = PieServer()
-    server.start()
+    main()

--- a/piemc/start.py
+++ b/piemc/start.py
@@ -1,0 +1,7 @@
+from piemc import config
+from piemc.server import PieServer
+
+
+def main():
+    server = PieServer()
+    server.start()

--- a/start.cmd
+++ b/start.cmd
@@ -1,14 +1,25 @@
 @echo off
 title PieMC Server Software for Minecraft: Bedrock Edition
 
+REM Find Python
+where py >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    where python >nul 2>&1
+    if %ERRORLEVEL% NEQ 0 (
+        echo Python not found.
+        pause
+        exit
+    )
+    set PYTHON=python
+) else (
+    set PYTHON=py
+)
+
 REM Install required dependencies silently
-python -m pip install -r requirements.txt > nul
+%PYTHON% -m pip install -r requirements.txt >nul 2>&1
 
 REM Start the server
-python start.py
-
-REM Display message after the server process has stopped
-echo Server process stopped.
+%PYTHON% -m piemc
 
 REM Pause the script to keep the window open for further inspection
 pause

--- a/start.py
+++ b/start.py
@@ -13,21 +13,7 @@
 # @author PieMC Team
 # @link http://www.PieMC-Dev.github.io/
 
-import subprocess
-def check_python_version():
-    try:
-        # Attempt to run the 'python' command and check if it's available
-        subprocess.check_output('python --version', shell=True)
-        return 'python'
-    except subprocess.CalledProcessError:
-        try:
-            # Attempt to run the 'python3' command and check if it's available
-            subprocess.check_output('python3 --version', shell=True)
-            return 'python3'
-        except subprocess.CalledProcessError:
-            raise Exception("Neither 'python' nor 'python3' found in your system.")
+from piemc import main
 
-
-selected_python_command = check_python_version()
-print(f"launching with the command: {selected_python_command}")
-subprocess.call(['python', '-m', 'piemc'])
+if __name__ == "__main__":
+    main()

--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 echo "PieMC Server Software for Minecraft: Bedrock Edition"
 
+# Find Python
+if command -v python3 >/dev/null 2>&1; then
+  python_executable="python3"
+elif command -v python >/dev/null 2>&1; then
+  python_executable="python"
+else
+  echo "Python not found"
+  exit 1
+fi
+
 # Install required dependencies silently
-pip install -r requirements.txt > /dev/null
+$python_executable -m pip install -r requirements.txt > /dev/null
 
 # Start the server
 python3 start.py
-
-# Display message after the server process has stopped
-echo "Server process stopped."
 
 # Pause the script to keep the terminal open for further inspection
 read -p "Press Enter to exit."


### PR DESCRIPTION
These starting commands weren't doing their best.

`start.cmd` and `start.sh` have been updated to check for multiple Python executables.

`start.py` no longer tries to find a Python executable. That's useless when we are already running a Python program 😅.

The `piemc` module was also updated so it would be compatible with these changes.